### PR TITLE
disable-release

### DIFF
--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -1,22 +1,22 @@
-version: v1.0
-name: Release
-agent:
-  machine:
-    type: e1-standard-2
-    os_image: ubuntu1804
-blocks:
-  - name: Release
-    skip:
-      when: "branch != 'main'"
-    task:
-      env_vars:
-        - name: BUNDLE_PATH
-          value: vendor/bundle
-      prologue:
-        commands_file: commands/prologue-common
-      secrets:
-        - name: github
-        - name: npm
-      jobs:
-        - name: Release
-          commands_file: commands/release
+# version: v1.0
+# name: Release
+# agent:
+#   machine:
+#     type: e1-standard-2
+#     os_image: ubuntu1804
+# blocks:
+#   - name: Release
+#     skip:
+#       when: "branch != 'main'"
+#     task:
+#       env_vars:
+#         - name: BUNDLE_PATH
+#           value: vendor/bundle
+#       prologue:
+#         commands_file: commands/prologue-common
+#       secrets:
+#         - name: github
+#         - name: npm
+#       jobs:
+#         - name: Release
+#           commands_file: commands/release

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -47,8 +47,8 @@ blocks:
       jobs:
         - name: Rubocop
           commands: ['bundle exec rake rubocop']
-promotions:
-  - name: Release
-    auto_promote:
-      when: "result = 'passed' AND branch = 'main'"
-    pipeline_file: release.yml
+# promotions:
+#   - name: Release
+#     auto_promote:
+#       when: "result = 'passed' AND branch = 'main'"
+#     pipeline_file: release.yml


### PR DESCRIPTION
[comment]: ####### (Assign it to at least 3 devs)

Changes introduced in this Pull Request:
- chore(semaphore): disable release since it implies pushes to npm

Ideal release flow is setting git tags and creating a github release, but not pushing any changes to npm. This can wait until later, since though it&#39;s a manual process, it shouldn&#39;t be hard to create releases via github. 
