### PR TITLE
skb-298-warn-on-each-slice

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,5 +11,8 @@ Naming/FileName:
   Exclude:
     - lib/rubocop-thinkific.rb
 
+RSpec/ExampleLength:
+  Max: 10
+
 AllCops:
   NewCops: enable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-thinkific (0.1.1)
+    rubocop-thinkific (0.2.0)
       rubocop (~> 1.9.1)
 
 GEM

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,8 @@
+Performance/NoEachSlice:
+  Description: 'Warns on calling #each_slice'
+  Enabled: true
+  VersionAdded: '0.2.0'
+
 Performance/PreferSizeToLength:
   Description: 'Warns on calling #length on objects instead of #size'
   Enabled: true

--- a/lib/rubocop/cop/performance/no_each_slice.rb
+++ b/lib/rubocop/cop/performance/no_each_slice.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Performance
+      # Warns when calling #find_each when we could use #find_each or #find_in_batches
+      #
+      # @example
+      #
+      #   # bad
+      #   array.each_slice { |slice| puts slice.first }
+      #
+      #   # bad
+      #   users = User.where(cool: true)
+      #   users.each_slice do |user|
+      #     puts user.first_name
+      #   end
+      #
+      #   # good
+      #   User.all.find_each do |user|
+      #     puts user.first_name
+      #   end
+      #
+      #   # good
+      #   User.find_in_batches do |batch|
+      #     puts batch.size
+      #   end
+      #
+      class NoEachSlice < Base
+        MSG = 'Use `#find_each` or `find_in_batches instead of `#each_slice`.'
+        RESTRICT_ON_SEND = %i[each_slice].freeze
+
+        def_node_matcher :bad_method?, <<~PATTERN
+          (send $_ :each_slice)
+        PATTERN
+
+        def on_send(node)
+          return unless bad_method?(node)
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/performance/no_each_slice.rb
+++ b/lib/rubocop/cop/performance/no_each_slice.rb
@@ -31,7 +31,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[each_slice].freeze
 
         def_node_matcher :bad_method?, <<~PATTERN
-          (send $_ :each_slice)
+          (send $_ :each_slice _?)
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/thinkific_cops.rb
+++ b/lib/rubocop/cop/thinkific_cops.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
+require_relative 'performance/no_each_slice'
 require_relative 'performance/prefer_size_to_length'

--- a/lib/rubocop/thinkific/version.rb
+++ b/lib/rubocop/thinkific/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Thinkific
-    VERSION = '0.1.1'
+    VERSION = '0.2.0'
   end
 end

--- a/spec/rubocop/cop/performance/no_each_slice_spec.rb
+++ b/spec/rubocop/cop/performance/no_each_slice_spec.rb
@@ -36,6 +36,17 @@ RSpec.describe RuboCop::Cop::Performance::NoEachSlice, :config do
             end
           RUBY
         end
+
+        it 'fails when method accepts param' do
+          expect_offense(<<~RUBY)
+            CSV.generate(options) do |csv|
+              tenant_ids.#{meth}(BATCH_SIZE) do |tenant_batch_ids|
+              #{warning_msg("tenant_ids.#{meth}(BATCH_SIZE)", msg)}
+                break if cancelled?
+              end
+            end
+          RUBY
+        end
       end
     end
   end

--- a/spec/rubocop/cop/performance/no_each_slice_spec.rb
+++ b/spec/rubocop/cop/performance/no_each_slice_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+MATCHING_METHODS = %w[each_slice].freeze
+NON_MATCHING_METHODS = %w[find_each find_in_batches].freeze
+
+RSpec.describe RuboCop::Cop::Performance::NoEachSlice, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+  let(:msg) { RuboCop::Cop::Performance::NoEachSlice::MSG }
+
+  context 'with an offense' do
+    MATCHING_METHODS.each do |meth|
+      context "when using `#{meth}`" do
+        it 'fails inline' do
+          expect_offense(<<~RUBY)
+            array.#{meth}
+            #{warning_msg("array.#{meth}", msg)}
+          RUBY
+        end
+
+        it 'fails in an if block' do
+          expect_offense(<<~RUBY)
+            if 3
+              array.#{meth}
+              #{warning_msg("array.#{meth}", msg)}
+            end
+          RUBY
+        end
+
+        it 'fails in a block' do
+          expect_offense(<<~RUBY)
+            User.all.#{meth} do |user|
+            #{warning_msg("User.all.#{meth}", msg)}
+              puts user.first_name
+            end
+          RUBY
+        end
+      end
+    end
+  end
+
+  context 'without an offense' do
+    MATCHING_METHODS.each do |meth|
+      context "when using `#{meth}`" do
+        it 'passes with send' do
+          expect_no_offenses(<<~RUBY)
+            array.send(:#{meth})
+          RUBY
+        end
+      end
+    end
+
+    NON_MATCHING_METHODS.each do |meth|
+      context "when using `#{meth}`" do
+        it 'passes inline' do
+          expect_no_offenses(<<~RUBY)
+            array.#{meth}
+          RUBY
+        end
+
+        it 'passes with send' do
+          expect_no_offenses(<<~RUBY)
+            array.send(:#{meth})
+          RUBY
+        end
+
+        it 'passes in a block' do
+          expect_no_offenses(<<~RUBY)
+            User.all.#{meth} do |user|
+              puts user.first_name
+            end
+          RUBY
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[comment]: ####### (Assign it to at least 3 devs)

[Warn on calls to #each_slice via rubocop-thinkific](https://thinkific.atlassian.net/browse/SKB-298)

Changes introduced in this Pull Request:
- feat(no_each_slice.rb): Add cop to warn when calling each_slice

each_slice is an Enumerable method available from Arrays and other objects. Unfortunately, ActiveRecord::Collection also inherits. Calling this method on an ActiveRecord::Collection loads every object in the relation into memory at once, which can cause our processes to be OOM (Out of Memory) killed. 
- chore(version): Bump version to 0.2.0
