### PR TITLE
snc-44-rubocop-thinkific-codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Global owners
+*   @kbluescode
+


### PR DESCRIPTION
[comment]: ####### (Assign it to at least 3 devs)

[Assign Owners for rubocop-thinkific](https://thinkific.atlassian.net/browse/SNC-44)

Changes introduced in this Pull Request:

- chore(.github/CODEOWNERS): Create code owners file and set global owner to kbluescode
